### PR TITLE
cicd-catalog updates

### DIFF
--- a/components/tekton/kustomization.yaml
+++ b/components/tekton/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./tasks
+  - ./pipelines

--- a/components/tekton/pipelines/kustomization.yaml
+++ b/components/tekton/pipelines/kustomization.yaml
@@ -2,6 +2,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+commonAnnotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+
+namespace: vse-cicd-catalog
+
 resources:
-  - ./build-image-from-git-repo/build-image-from-git-repo.yaml
-  - ./run-testsuite-from-image/run-testsuite-from-image.yaml
+    - ./build-image-from-git-repo/build-image-from-git-repo.yaml
+    - ./run-testsuite-from-image/run-testsuite-from-image.yaml

--- a/components/tekton/pipelines/run-testsuite-from-image/run-testsuite-from-image.yaml
+++ b/components/tekton/pipelines/run-testsuite-from-image/run-testsuite-from-image.yaml
@@ -25,6 +25,9 @@ spec:
     - name: NAMESPACE
     - name: NOTIF_URL
     - name: MESSAGE
+    - name: WORKER1
+    - name: WORKER2
+    - name: INTERFACES
   tasks:
     - name: send-notification
       taskRef:
@@ -62,8 +65,14 @@ spec:
           value: $(params.CLUSTER_NAME)
         - name: NAMESPACE
           value: $(params.NAMESPACE)
+        - name: NODE1
+          value: $(params.WORKER1)
+        - name: NODE2
+          value: $(params.WORKER2)
+        - name: INTERFACE_LIST
+          value: $(params.INTERFACES)
       workspaces:
-        - name: kubeconfig
+        - name: kubeconfigs
           workspace: pipeline-ws
     - name: send-report
       taskRef:

--- a/components/tekton/tasks/catalog-ns.yaml
+++ b/components/tekton/tasks/catalog-ns.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vse-cicd-catalog

--- a/components/tekton/tasks/kustomization.yaml
+++ b/components/tekton/tasks/kustomization.yaml
@@ -2,12 +2,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: vse-cicd-catalog
+
+commonAnnotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+
 resources:
-  - git-clone.yaml
-  - list-directory.yaml
-  - send-to-gchat.yaml
-  - write-file.yaml
-  - get-kubeconfig.yaml
-  - buildah.yaml
-  - set-tag.yaml
-  - deploy-gotests.yaml
+    - catalog-ns.yaml
+    - git-clone.yaml
+    - list-directory.yaml
+    - send-to-gchat.yaml
+    - write-file.yaml
+    - get-kubeconfig.yaml
+    - buildah.yaml
+    - set-tag.yaml
+    - deploy-gotests.yaml


### PR DESCRIPTION
- Generalize deploy-go-tests with additional parameters so that the pipeline using this task can be used in different environment (node names, interface names,..)
- Make task and pipeline catalog able to be created from argoCD appset
- catalog created in ns vse-cicd-catalog to be consumed from managed cluster ns