### PR TITLE
ArgoCD patch required for ZTP deployments

### DIFF
--- a/components/argocd/README.md
+++ b/components/argocd/README.md
@@ -1,0 +1,21 @@
+# ArgoCD patch required for ZTP deployments 
+
+The following patch is required for ZTP worload clusters to be deployed from vse-carslab-hub repository
+
+The current *overlays* available are for the following versions:
+* [4.10](overlays/4.10)
+* [4.11](overlays/4.11)
+* [4.12](overlays/4.12)
+
+There is also a default included if you want to not have this ztp argocd patch included.
+* [default](overlays/default)
+
+## Usage
+
+As part of redhat-partner-solutions/vse-carslab-hub/bootstrap/overlays/default/kustomization.yaml:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - github.com/redhat-partner-solutions/vse-catalog/components/argocd/overlays/<version>?ref=main

--- a/components/argocd/base/kustomization.yaml
+++ b/components/argocd/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - openshift-gitops-argocd.yaml

--- a/components/argocd/base/openshift-gitops-argocd.yaml
+++ b/components/argocd/base/openshift-gitops-argocd.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  notifications:
+    enabled: true
+  applicationSet:
+    resources:
+      limits:
+        cpu: "2"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 512Mi
+  controller:
+    processors: {}
+    resources:
+      limits:
+        cpu: "16"
+        memory: 32Gi
+      requests:
+        cpu: 1
+        memory: 2Gi
+    sharding: {}
+  kustomizeBuildOptions: "--enable-alpha-plugins"
+  repo:
+    volumes:
+    - name: kustomize
+    initContainers:
+    - resources: {}
+      terminationMessagePath: "/dev/termination-log"
+      name: kustomize-plugin
+      command:
+      - "/exportkustomize.sh"
+      args:
+      - "/.config"
+      imagePullPolicy: Always
+      volumeMounts:
+      - name: kustomize
+        mountPath: "/.config"
+      terminationMessagePolicy: File
+      image: quay.io/openshift-kni/ztp-site-generator:<patch-me>
+    volumeMounts:
+    - name: kustomize
+      readOnly: false
+      mountPath: "/.config"
+    env:
+    - name: ARGOCD_EXEC_TIMEOUT
+      value: 360s
+    - name: KUSTOMIZE_PLUGIN_HOME
+      value: "/.config/kustomize/plugin"
+    resources:
+      limits:
+        cpu: '8'
+        memory: 16Gi
+      requests:
+        cpu: '1'
+        memory: 2Gi
+  # yamllint disable rule:line-length
+  resourceCustomizations: |
+    bitnami.com/SealedSecret:
+      health.lua: |
+        hs = {}
+        hs.status = "Healthy"
+        hs.message = "Controller doesnt report status"
+        return hs
+    route.openshift.io/Route:
+      ignoreDifferences: |
+        jsonPointers:
+        - /spec/host
+    internal.open-cluster-management.io/ManagedClusterInfo:
+      health.lua: |
+          hs = {}
+          if obj.status ~= nil and obj.status.conditions ~= nil then
+            for i, condition in ipairs(obj.status.conditions) do
+              if condition.status == "True" and condition.reason == "ManagedClusterInfoSynced" then
+                hs.status = "Healthy"
+                hs.message = "Managed cluster is added to hub cluster"
+                return hs
+              end
+            end
+          end
+          hs.status = "Progressing"
+          hs.message = "Waiting for managed cluster to be deployed."
+          return hs
+  # yamllint enable rule:line-length
+  resourceExclusions: |
+    - apiGroups:
+      - tekton.dev
+      clusters:
+      - '*'
+      kinds:
+      - TaskRun
+      - PipelineRun

--- a/components/argocd/overlays/4.10/kustomization.yaml
+++ b/components/argocd/overlays/4.10/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/openshift-gitops-argocd.yaml
+
+patches:
+  - target:
+      kind: ArgoCD
+    patch: |-
+      - op: add
+        path: /spec/repo/initContainers/0/image
+        value: quay.io/openshift-kni/ztp-site-generator:4.10.0

--- a/components/argocd/overlays/4.11/kustomization.yaml
+++ b/components/argocd/overlays/4.11/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/openshift-gitops-argocd.yaml
+
+patches:
+  - target:
+      kind: ArgoCD
+    patch: |-
+      - op: add
+        path: /spec/repo/initContainers/0/image
+        value: quay.io/openshift-kni/ztp-site-generator:4.11.0

--- a/components/argocd/overlays/4.12/kustomization.yaml
+++ b/components/argocd/overlays/4.12/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  
+patches:
+  - target:
+      kind: ArgoCD
+    patch: |-
+      - op: replace
+        path: /spec/repo/initContainers/0/image
+        value: quay.io/openshift-kni/ztp-site-generator:4.12.0

--- a/components/argocd/overlays/default/kustomization.yaml
+++ b/components/argocd/overlays/default/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - openshift-gitops-argocd.yaml

--- a/components/argocd/overlays/default/openshift-gitops-argocd.yaml
+++ b/components/argocd/overlays/default/openshift-gitops-argocd.yaml
@@ -1,0 +1,145 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  notifications:
+    enabled: true
+  applicationSet:
+    resources:
+      limits:
+        cpu: "2"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 512Mi
+  controller:
+    processors: {}
+    resources:
+      limits:
+        cpu: "2"
+        memory: 2Gi
+      requests:
+        cpu: 250m
+        memory: 1Gi
+    sharding: {}
+  dex:
+    openShiftOAuth: true
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  grafana:
+    enabled: false
+    ingress:
+      enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+    route:
+      enabled: false
+  ha:
+    enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  initialSSHKnownHosts: {}
+  prometheus:
+    enabled: false
+    ingress:
+      enabled: false
+    route:
+      enabled: false
+  rbac:
+    policy: g, system:cluster-admins, role:admin
+    scopes: '[groups]'
+  redis:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  repo:
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+  # yamllint disable rule:line-length
+  resourceCustomizations: |
+    bitnami.com/SealedSecret:
+      health.lua: |
+        hs = {}
+        hs.status = "Healthy"
+        hs.message = "Controller doesnt report status"
+        return hs
+    route.openshift.io/Route:
+      ignoreDifferences: |
+        jsonPointers:
+        - /spec/host
+    internal.open-cluster-management.io/ManagedClusterInfo:
+      health.lua: |
+          hs = {}
+          if obj.status ~= nil and obj.status.conditions ~= nil then
+            for i, condition in ipairs(obj.status.conditions) do
+              if condition.status == "True" and condition.reason == "ManagedClusterInfoSynced" then
+                hs.status = "Healthy"
+                hs.message = "Managed cluster is added to hub cluster"
+                return hs
+              end
+            end
+          end
+          hs.status = "Progressing"
+          hs.message = "Waiting for managed cluster to be deployed."
+          return hs
+  # yamllint enable rule:line-length
+  resourceExclusions: |
+    - apiGroups:
+      - tekton.dev
+      clusters:
+      - '*'
+      kinds:
+      - TaskRun
+      - PipelineRun
+  server:
+    autoscale:
+      enabled: false
+    grpc:
+      ingress:
+        enabled: false
+    ingress:
+      enabled: false
+    insecure: true
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    route:
+      enabled: true
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: edge
+    service:
+      type: ""
+  tls:
+    ca: {}


### PR DESCRIPTION
The following patch is required for ZTP worload clusters to be deployed from vse-carslab-hub repository

The current overlays available are for the following versions:

    [4.10](https://github.com/hhamid93/vse-catalog/blob/argocd/components/argocd/overlays/4.10)
    [4.11](https://github.com/hhamid93/vse-catalog/blob/argocd/components/argocd/overlays/4.11)
    [4.12](https://github.com/hhamid93/vse-catalog/blob/argocd/components/argocd/overlays/4.12)

There is also a default included if you want to not have this ztp argocd patch included.

    [default](https://github.com/hhamid93/vse-catalog/blob/argocd/components/argocd/overlays/default)