### PR TITLE
Fix dex creation

### DIFF
--- a/components/argocd/base/openshift-gitops-argocd.yaml
+++ b/components/argocd/base/openshift-gitops-argocd.yaml
@@ -95,3 +95,7 @@ spec:
       kinds:
       - TaskRun
       - PipelineRun
+  sso:
+    provider: dex
+    dex:
+      openShiftOAuth: true


### PR DESCRIPTION
SSO section is missing in the Argo CD manifest.
This manifest needed to be added in order to create the Dex pods:
```
sso:
  provider: dex
  dex:
    openShiftOAuth: true
```