### PR TITLE
switch to downstream supported ZTP plugin

### DIFF
--- a/components/argocd/overlays/4.10/kustomization.yaml
+++ b/components/argocd/overlays/4.10/kustomization.yaml
@@ -11,4 +11,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/repo/initContainers/0/image
-        value: quay.io/openshift-kni/ztp-site-generator:4.10.0
+        value: registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.10.2

--- a/components/argocd/overlays/4.11/kustomization.yaml
+++ b/components/argocd/overlays/4.11/kustomization.yaml
@@ -11,4 +11,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/repo/initContainers/0/image
-        value: quay.io/openshift-kni/ztp-site-generator:4.11.0
+        value: registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.11

--- a/components/argocd/overlays/4.12/kustomization.yaml
+++ b/components/argocd/overlays/4.12/kustomization.yaml
@@ -11,4 +11,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/repo/initContainers/0/image
-        value: quay.io/openshift-kni/ztp-site-generator:4.12.0
+        value: registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.12

--- a/components/argocd/overlays/4.13/kustomization.yaml
+++ b/components/argocd/overlays/4.13/kustomization.yaml
@@ -11,4 +11,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/repo/initContainers/0/image
-        value: quay.io/openshift-kni/ztp-site-generator:4.13.0
+        value: registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.13


### PR DESCRIPTION
This PR:

Switches from using the Engineering (constantly changing) version of the ztp-site-generate plugin (hosted on quay.io's KNI organization) to the downstream, supported one hosted in Red Hat's Ecosystem Catalog:

https://catalog.redhat.com/software/containers/openshift4/ztp-site-generate-rhel8/6154c29fd2c7f84a4d2edca1?gs&q=ztp