### PR TITLE
Update Argo CD resource

### DIFF
--- a/components/argocd/base/openshift-gitops-argocd.yaml
+++ b/components/argocd/base/openshift-gitops-argocd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: openshift-gitops
@@ -60,32 +60,37 @@ spec:
         cpu: '1'
         memory: 2Gi
   # yamllint disable rule:line-length
-  resourceCustomizations: |
-    bitnami.com/SealedSecret:
-      health.lua: |
+  resourceHealthChecks:
+    - group: bitnami.com
+      kind: SealedSecret
+      check: |
         hs = {}
         hs.status = "Healthy"
         hs.message = "Controller doesnt report status"
         return hs
-    route.openshift.io/Route:
-      ignoreDifferences: |
-        jsonPointers:
-        - /spec/host
-    internal.open-cluster-management.io/ManagedClusterInfo:
-      health.lua: |
-          hs = {}
-          if obj.status ~= nil and obj.status.conditions ~= nil then
-            for i, condition in ipairs(obj.status.conditions) do
-              if condition.status == "True" and condition.reason == "ManagedClusterInfoSynced" then
-                hs.status = "Healthy"
-                hs.message = "Managed cluster is added to hub cluster"
-                return hs
-              end
+    - group: internal.open-cluster-management.io
+      kind: ManagedClusterInfo
+      check: |
+        hs = {}
+        if obj.status ~= nil and obj.status.conditions ~= nil then
+          for i, condition in ipairs(obj.status.conditions) do
+            if condition.status == "True" and condition.reason == "ManagedClusterInfoSynced" then
+              hs.status = "Healthy"
+              hs.message = "Managed cluster is added to hub cluster"
+              return hs
             end
           end
-          hs.status = "Progressing"
-          hs.message = "Waiting for managed cluster to be deployed."
-          return hs
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for managed cluster to be deployed."
+        return hs
+  resourceIgnoreDifferences:
+    resourceIdentifiers:
+      - group: route.openshift.io
+        kind: Route
+        customization:
+          jsonPointers:
+            - /spec/host
   # yamllint enable rule:line-length
   resourceExclusions: |
     - apiGroups:


### PR DESCRIPTION
Update Argo CD base.
- Remove `.spec.resourceCustomizations` as deprecated
- Update Argo CD to `v1beta1`

Fix #41 