### PR TITLE
seed 4.14 version of the ZTP plugin

### DIFF
--- a/components/argocd/README.md
+++ b/components/argocd/README.md
@@ -7,6 +7,7 @@ The current *overlays* available are for the following versions:
 * [4.11](overlays/4.11)
 * [4.12](overlays/4.12)
 * [4.13](overlays/4.13)
+* [4.14](overlays/4.14)
 
 
 There is also a default included if you want to not have this ztp argocd patch included.
@@ -31,5 +32,5 @@ As part of a different overlay in your own GitOps repo:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - github.com/redhat-partner-solutions/vse-catalog/components/argocd/overlays/<version>?ref=mai
+  - github.com/redhat-partner-solutions/vse-catalog/components/argocd/overlays/<version>?ref=main
 ```

--- a/components/argocd/overlays/4.14/kustomization.yaml
+++ b/components/argocd/overlays/4.14/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: ArgoCD
+    patch: |-
+      - op: replace
+        path: /spec/repo/initContainers/0/image
+        value: registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.14


### PR DESCRIPTION
This PR:

1. Seeds version 4.14 of the ztp-site-generate plugin, responsible for driving ZTP deployments via RHACM.
2. Updates typos in the README, and adds a link to the folder containing the 4.14 kustomize.